### PR TITLE
Fix engine verification and update frontend

### DIFF
--- a/api/routes_health.py
+++ b/api/routes_health.py
@@ -13,9 +13,6 @@ from sqlalchemy.exc import OperationalError
 import logging
 import requests
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 bp = Blueprint("health", __name__)

--- a/api/routes_query.py
+++ b/api/routes_query.py
@@ -25,12 +25,8 @@ from functools import lru_cache
 
 from flask import Blueprint, jsonify, request
 from werkzeug.exceptions import BadRequest
-from dotenv import load_dotenv
 
 from core.db.query_engine import QueryEngine
-
-# Ensure environment variables are loaded
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 bp = Blueprint("query", __name__, url_prefix="/api")

--- a/app.py
+++ b/app.py
@@ -1,6 +1,4 @@
-from dotenv import load_dotenv
-# Load environment variables first, before any other imports
-load_dotenv()
+import logging
 
 # Suppress TensorFlow and CUDA warnings
 import os
@@ -15,11 +13,17 @@ from api.routes_query import bp as query_bp
 from api.routes_chart import bp as chart_bp
 from api.routes_health import bp as health_bp
 from config import AppConfig
-import os
 
 def create_app() -> Flask:
     """Flask application factory"""
     app = Flask(__name__)
+
+    # Configure logging once
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )
 
     # Load configuration
     config = AppConfig()

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -87,7 +87,7 @@ select option {
     font-weight: normal;
     font-style: normal;
     padding: 5px;
-} */
+}
 header {
     text-align: center;
     margin-bottom: 2rem;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -138,11 +138,11 @@ function handleQueryResponse(data) {
     }
 
     // Display SQL query
-    sqlOutput.textContent = data.sql_query || 'No SQL generated';
+    sqlOutput.textContent = data.sql || 'No SQL generated';
 
     // Display data results
-    if (data.result && data.result.length > 0) {
-        dataOutput.textContent = JSON.stringify(data.result, null, 2);
+    if (data.data && data.data.length > 0) {
+        dataOutput.textContent = JSON.stringify(data.data, null, 2);
     } else {
         dataOutput.textContent = 'No data returned';
     }
@@ -158,8 +158,8 @@ function handleChartResponse(data) {
     }
 
     // Display SQL query
-    if (data.sql_query) {
-        sqlOutput.textContent = data.sql_query;
+    if (data.sql) {
+        sqlOutput.textContent = data.sql;
     }
 
     // Display data results
@@ -233,7 +233,7 @@ function loadSampleQuestions() {
 // Health check function
 async function checkHealth() {
     try {
-        const response = await fetch('/api/health');
+        const response = await fetch('/healthz');
         const data = await response.json();
         console.log('Health check:', data);
         return data.status === 'healthy';


### PR DESCRIPTION
## Summary
- pass engine to `verify_sql` and improve LLM error handling
- return similarity search scores
- add field ranking heuristics for chart generation
- configure basic logging in the Flask app
- sync frontend field names and health check path
- clean stray CSS comment
- remove redundant `.env` loading

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888af5475d883248e83f860783be147