### PR TITLE
Use LangChain SQL agent

### DIFF
--- a/api/routes_query.py
+++ b/api/routes_query.py
@@ -11,9 +11,7 @@ Body (JSON):
 
 Response:
 {
-  "sql": "...",
-  "data": [ { ... }, ... ],
-  "rowcount": 42
+  "answer": "<natural language answer>"
 }
 """
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -149,14 +149,11 @@ function handleQueryResponse(data) {
         return;
     }
 
-    // Display SQL query
-    sqlOutput.textContent = data.sql || 'No SQL generated';
-
-    // Display data results
-    if (data.data && data.data.length > 0) {
-        dataOutput.textContent = JSON.stringify(data.data, null, 2);
+    // Display agent answer
+    if (data.answer) {
+        sqlOutput.textContent = data.answer;
     } else {
-        dataOutput.textContent = 'No data returned';
+        sqlOutput.textContent = 'No answer returned';
     }
 
     // Switch to SQL tab to show results

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@
 
                 <div class="tab-content">
                     <div id="sql-tab" class="tab-pane active">
-                        <h3>Generated SQL</h3>
+                        <h3>Agent Answer</h3>
                         <pre><code id="sql-output">No query executed yet.</code></pre>
                     </div>
 


### PR DESCRIPTION
## Summary
- swap out custom query engine logic for a LangChain SQL agent
- track SQL statements via custom `LoggingSQLDatabase`
- adjust API response docs and frontend JS to show agent answer
- update UI label from "Generated SQL" to "Agent Answer"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c02a07f083248eb96c921146af88