### PR TITLE
Fix API responses and chart data output

### DIFF
--- a/api/routes_query.py
+++ b/api/routes_query.py
@@ -75,8 +75,11 @@ def run_query():
         suggestions = []
 
     return jsonify({
-        "answer": result,
-        "embedding_suggestions": suggestions
+        "answer": result.get("answer"),
+        "sql": result.get("sql"),
+        "data": result.get("data"),
+        "rowcount": result.get("rowcount"),
+        "embedding_suggestions": suggestions,
     }), 200
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -156,6 +156,18 @@ function handleQueryResponse(data) {
         sqlOutput.textContent = 'No answer returned';
     }
 
+    // Show SQL query if returned
+    if (data.sql) {
+        sqlOutput.textContent += `\nSQL: ${data.sql}`;
+    }
+
+    // Display data rows if available
+    if (data.data && data.data.length > 0) {
+        dataOutput.textContent = JSON.stringify(data.data, null, 2);
+    } else {
+        dataOutput.textContent = 'No data returned';
+    }
+
     // Display embedding suggestions if available
     const suggestionsDiv = document.getElementById('embedding-suggestions');
     if (suggestionsDiv) {


### PR DESCRIPTION
## Summary
- ensure `LoggingSQLDatabase` stores processed rows for reuse
- include rowcount in `QueryEngine.ask`
- return structured fields from query endpoint
- show SQL and data results in the frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c7edd6f483249d2c2be4e793d450