### PR TITLE
Add dark mode UI

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -5,11 +5,25 @@
     box-sizing: border-box;
 }
 
+:root {
+    --bg-color: #f5f5f5;
+    --text-color: #333;
+    --header-bg: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    --section-bg: #ffffff;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.6;
-    color: #333;
-    background-color: #f5f5f5;
+    color: var(--text-color);
+    background-color: var(--bg-color);
+}
+
+body.dark-mode {
+    --bg-color: #1e1e1e;
+    --text-color: #eee;
+    --header-bg: linear-gradient(135deg, #2c3e50 0%, #4b79a1 100%);
+    --section-bg: #2b2b2b;
 }
 
 .container {
@@ -136,10 +150,14 @@ select option {
     padding: 5px;
 }
 header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
     text-align: center;
     margin-bottom: 2rem;
     padding: 2rem 0;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: var(--header-bg);
     color: white;
     border-radius: 10px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -157,7 +175,7 @@ header p {
 
 /* Section Styles */
 section {
-    background: white;
+    background: var(--section-bg);
     margin-bottom: 2rem;
     padding: 2rem;
     border-radius: 10px;
@@ -243,6 +261,12 @@ input[type="text"]:focus, textarea:focus, select:focus {
     opacity: 0.6;
     cursor: not-allowed;
     transform: none;
+}
+
+.theme-toggle {
+    position: absolute;
+    top: 15px;
+    right: 20px;
 }
 
 /* Tab Styles */
@@ -457,4 +481,20 @@ code {
     height: 40px;      /* kutunun yüksekliği */
     padding: 8px 12px; /* iç boşluk; yazı alanını büyütür */
     line-height: 1.4;  /* yazının dikey hizasını dengeler */
+}
+
+/* Dark mode adjustments */
+body.dark-mode pre {
+    background: #2d2d2d;
+    border-color: #444;
+    color: #eee;
+}
+
+body.dark-mode code {
+    color: #ff79c6;
+}
+
+body.dark-mode #chart-output {
+    border-color: #555;
+    color: #ccc;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -9,6 +9,7 @@ const dataOutput = document.getElementById('data-output');
 const chartOutput = document.getElementById('chart-output');
 const loadingDiv = document.getElementById('loading');
 const errorDiv = document.getElementById('error');
+const themeToggle = document.getElementById('theme-toggle');
 
 // Tab functionality
 const tabBtns = document.querySelectorAll('.tab-btn');
@@ -21,6 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (savedDbUri) {
         dbUriInput.value = savedDbUri;
     }
+
+    // Apply saved theme
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    setTheme(savedTheme);
     
     // Setup event listeners
     setupEventListeners();
@@ -70,6 +75,15 @@ function setupEventListeners() {
             executeQuery();
         }
     });
+
+    // Theme toggle
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            const newTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+            setTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    }
 }
 
 function switchTab(tabName) {
@@ -364,3 +378,17 @@ checkHealth().then(healthy => {
         showError('Backend service is not responding. Please check the server.');
     }
 });
+
+function setTheme(mode) {
+    if (mode === 'dark') {
+        document.body.classList.add('dark-mode');
+        if (themeToggle) {
+            themeToggle.textContent = '☀️ Light Mode';
+        }
+    } else {
+        document.body.classList.remove('dark-mode');
+        if (themeToggle) {
+            themeToggle.textContent = '🌙 Dark Mode';
+        }
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
         <header>
             <h1>🤖 LangChain SQL Agent</h1>
             <p>Natural language to SQL queries with interactive charts</p>
+            <button id="theme-toggle" class="btn btn-secondary theme-toggle">🌙 Dark Mode</button>
         </header>
 
         <main>


### PR DESCRIPTION
## Summary
- implement dark mode CSS variables
- add a theme toggle button in the header
- hook up toggle logic in `app.js`

## Testing
- `pytest -q`
- `flake8` *(fails: E501 line too long and other style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6889cd43c9688324aec27adbfab1fabe