### PR TITLE
Fix agent error handling

### DIFF
--- a/core/db/query_engine.py
+++ b/core/db/query_engine.py
@@ -107,7 +107,14 @@ class QueryEngine:
 
         self.db = LoggingSQLDatabase(self.engine)
         toolkit = SQLDatabaseToolkit(db=self.db, llm=self.llm)
-        self.agent = create_sql_agent(llm=self.llm, toolkit=toolkit, verbose=False)
+        # Pass handle_parsing_errors=True so that the agent can retry when
+        # the LLM returns malformed output instead of raising an exception.
+        self.agent = create_sql_agent(
+            llm=self.llm,
+            toolkit=toolkit,
+            verbose=False,
+            agent_executor_kwargs={"handle_parsing_errors": True},
+        )
 
         logger.info(f"Using OpenRouter with model: {llm_model}")
 


### PR DESCRIPTION
## Summary
- handle parsing errors gracefully so the agent can retry

## Testing
- `ruff check core/db/query_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ee5454ac8324b97b84ab7a5a2712